### PR TITLE
Fix Function Style Reference in styles Configuration

### DIFF
--- a/lua/modus-themes/theme.lua
+++ b/lua/modus-themes/theme.lua
@@ -100,7 +100,7 @@ function M.setup()
 		StorageClass = { fg = c.magenta_cooler }, -- static, register, volatile, etc.
 		Structure = { fg = c.magenta_cooler }, -- struct, union, enum, etc.
 		Constant = { fg = c.blue_cooler }, -- (preferred) any constant
-		Function = { fg = c.magenta, style = options.styles.variables }, -- Function name (also: methods for classes)
+		Function = { fg = c.magenta, style = options.styles.functions }, -- Function name (also: methods for classes)
 		Identifier = { fg = c.cyan, style = options.styles.variables }, -- (preferred) any variable name
 		Include = { fg = c.red_cooler }, -- preprocessor #include
 		PreProc = { fg = c.red_cooler }, -- (preferred) generic Preprocessor


### PR DESCRIPTION
## Summary
This pull request corrects the styling reference for functions in the styles configuration. Previously, the style for functions was inadvertently set to `options.styles.variables`. This change ensures that functions use their designated `options.styles.functions` styling.

## Details
In the project's README, under the styles configuration, different syntax groups like comments, keywords, functions, and variables are supposed to have their unique styling. However, I noticed that the styling for functions was not being applied as intended. Instead, it was mirroring the style of variables.

## Change
Updated the line in the configuration to correctly reference `options.styles.functions` for the function syntax group. This minor change aligns the styling behavior with the documented structure and intended functionality.