### PR TITLE
Support diff in Tree-sitter

### DIFF
--- a/lua/modus-themes/treesitter.lua
+++ b/lua/modus-themes/treesitter.lua
@@ -149,6 +149,18 @@ M.defaults = {
 		default = true,
 		link = "Define",
 	},
+	["@diff.delta"] = {
+		default = true,
+		link = "DiffChange",
+	},
+	["@diff.minus"] = {
+		default = true,
+		link = "DiffDelete",
+	},
+	["@diff.plus"] = {
+		default = true,
+		link = "DiffAdd",
+	},
 	["@exception"] = {
 		default = true,
 		link = "Exception",


### PR DESCRIPTION
Adds support for the diff language in Tree-sitter. This is useful, for example, when editing commits in Neovim using the verbose option.

Previously, diffs were not highlighted.

Below are before and after screenshots demonstrating the change.

Before:

<img width="841" alt="before" src="https://github.com/miikanissi/modus-themes.nvim/assets/12143269/db80a498-db18-4fca-8c78-5974048dc6a5">

After:

<img width="841" alt="after" src="https://github.com/miikanissi/modus-themes.nvim/assets/12143269/34a3de69-0b8f-406d-bad4-5659ed03e992">