### PR TITLE
Make mini.statusline dev information bold

### DIFF
--- a/lua/modus-themes/colors.lua
+++ b/lua/modus-themes/colors.lua
@@ -317,7 +317,7 @@ M.modus_vivendi = {
 	bg_inactive = "#282828",
 	fg_inactive = "#bfc0c4",
 	-- Status line specific colors
-	bg_status_line_active = "#505050",
+	bg_status_line_active = "#404040",
 	fg_status_line_active = "#f0f0f0",
 	bg_status_line_inactive = "#2d2d2d",
 	fg_status_line_inactive = "#969696",
@@ -364,7 +364,7 @@ M.modus_vivendi = {
 	tinted_bg_completion = "#483d8a",
 	tinted_bg_hl_line = "#303a6f",
 	tinted_bg_paren_match = "#2f7f9f",
-	tinted_bg_status_line_active = "#484d67",
+	tinted_bg_status_line_active = "#393F51",
 	tinted_bg_status_line_inactive = "#292d48",
 	tinted_bg_tab_bar = "#2c3045",
 	tinted_bg_tab_current = "#0d0e1c",

--- a/lua/modus-themes/theme.lua
+++ b/lua/modus-themes/theme.lua
@@ -671,7 +671,7 @@ function M.setup()
 		MiniStarterItemPrefix = { fg = c.yellow_cooler },
 		MiniStarterSection = { fg = c.blue_warmer },
 		MiniStarterQuery = { fg = c.blue_cooler },
-		MiniStatuslineDevinfo = { fg = c.blue_faint, bg = c.bg_status_line_active },
+		MiniStatuslineDevinfo = { fg = c.blue_faint, bg = c.bg_status_line_active, bold = true },
 		MiniStatuslineFileinfo = { fg = c.fg_status_line_active, bg = c.bg_status_line_active },
 		MiniStatuslineFilename = { fg = c.fg_status_line_active, bg = c.bg_status_line_active },
 		MiniStatuslineInactive = { fg = c.fg_status_line_inactive, bg = c.bg_status_line_inactive, bold = true },


### PR DESCRIPTION
The contrast of the dev info text to the background is low (3.59:1), which fails WCAG AA standard. This information is inactive, so failing the standard is acceptable per the README. However, it is still quite hard to read due to the low contrast.

By making the dev info bold, the text becomes much easier to read. This appears to be the behaviour in the README screenshot, which features lualine. This patch would make the mini.statusline behaviour consistent with lualine.

Before:

<img width="753" alt="Screenshot 2024-05-14 at 00 03 27" src="https://github.com/miikanissi/modus-themes.nvim/assets/12143269/4b4d45f5-c6ce-45f4-b3a3-259fa78702c9">

After:

<img width="753" alt="Screenshot 2024-05-14 at 00 03 18" src="https://github.com/miikanissi/modus-themes.nvim/assets/12143269/a4c2c8ff-aca7-4da2-a383-6c92ce302d56">
