### PR TITLE
feat: add ability to hide inactive statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ require("modus-themes").setup({
 	variant = "default", -- Theme comes in four variants `default`, `tinted`, `deuteranopia`, and `tritanopia`
 	transparent = false, -- Transparent background (as supported by the terminal)
 	dim_inactive = false, -- "non-current" windows are dimmed
+	hide_inactive_statusline = false, -- Hide statuslines on inactive windows. Works with the standard **StatusLine**, **LuaLine** and **mini.statusline**
 	styles = {
 		-- Style to be applied to different syntax groups
 		-- Value is any valid attr-list value for `:help nvim_set_hl`

--- a/lua/modus-themes/config.lua
+++ b/lua/modus-themes/config.lua
@@ -10,6 +10,7 @@ local defaults = {
 	variant = "default", -- Theme comes in four variants `default`, `tinted`, `deuteranopia`, and `tritanopia`
 	transparent = false, -- Transparent background (as supported by the terminal)
 	dim_inactive = false, -- "non-current" windows are dimmed
+	hide_inactive_statusline = false, -- Hide statuslines on inactive windows. Works with the standard **StatusLine**, **LuaLine** and **mini.statusline**
 	styles = {
 		-- Style to be applied to different syntax groups
 		-- Value is any valid attr-list value for `:help nvim_set_hl`

--- a/lua/modus-themes/theme.lua
+++ b/lua/modus-themes/theme.lua
@@ -937,6 +937,21 @@ function M.setup()
 	---@type table<string, table>
 	theme.defer = {}
 
+	if options.hide_inactive_statusline then
+		local inactive = { underline = true, bg = c.none, fg = bg_main, sp = c.border }
+
+		-- StatusLineNC
+		theme.highlights.StatusLineNC = inactive
+
+		-- LuaLine
+		for _, section in ipairs({ "a", "b", "c" }) do
+			theme.defer["lualine_" .. section .. "_inactive"] = inactive
+		end
+
+		-- mini.statusline
+		theme.highlights.MiniStatuslineInactive = inactive
+	end
+
 	options.on_highlights(theme.highlights, theme.colors)
 
 	return theme


### PR DESCRIPTION
Add ability to hide statusline on inactive windows. Supports the standard statusline, lualine, and mini.statusline.

Feature shamelessly copied from tokyonight.nvim.