### PR TITLE
fix(extras): colorize missing Fish `color_option`

### DIFF
--- a/lua/modus-themes/extras/fish.lua
+++ b/lua/modus-themes/extras/fish.lua
@@ -34,6 +34,7 @@ set -g fish_color_keyword $pink
 set -g fish_color_quote $yellow
 set -g fish_color_redirection $foreground
 set -g fish_color_end $orange
+set -g fish_color_option $pink
 set -g fish_color_error $red
 set -g fish_color_param $purple
 set -g fish_color_comment $comment


### PR DESCRIPTION
Tokyonight was missing this feature, but I submitted a pull request to fix it, which was merged 3 months ago. You can check it out here: [PR #586](https://github.com/folke/tokyonight.nvim/pull/586).

Current state of Tokyonight: https://github.com/folke/tokyonight.nvim/blob/2c85fad417170d4572ead7bf9fdd706057bd73d7/lua/tokyonight/extra/fish.lua#L35