### PR TITLE
Fix Tilix Modus Vivendi and Modus Operandi themes

### DIFF
--- a/lua/modus-themes/extras/tilix.lua
+++ b/lua/modus-themes/extras/tilix.lua
@@ -8,7 +8,7 @@ function M.generate(colors)
 		[[
 {
     "name": "${_style_name}",
-    "comment": "Highly accessible theme, conforming with the highest standard for color contrast between background and foreground values (WCAG AAA)."
+    "comment": "Highly accessible theme, conforming with the highest standard for color contrast between background and foreground values (WCAG AAA).",
     "use-theme-colors": false,
     "foreground-color": "${fg_main}",
     "background-color": "${bg_main}",


### PR DESCRIPTION
There was a missing comma after the "comment" field on both json files.

> [!Note]
> Tested on Blackbox, which uses Tilix themes.