### PR TITLE
extras(ghostty): better bg color8

### DIFF
--- a/lua/modus-themes/extras/ghostty.lua
+++ b/lua/modus-themes/extras/ghostty.lua
@@ -24,7 +24,7 @@ palette = 4=#${blue}
 palette = 5=#${magenta}
 palette = 6=#${cyan}
 palette = 7=#${fg_main}
-palette = 8=#${bg_dim}
+palette = 8=#${bg_active}
 palette = 9=#${red_intense}
 palette = 10=#${green_intense}
 palette = 11=#${yellow_intense}


### PR DESCRIPTION
This PR make color1 and color8 more distinguishable in Ghostty, easier on eyes.

Before:
![CleanShot 2025-03-04 at 02 37 40@2x](https://github.com/user-attachments/assets/19dea16e-c64c-4bce-9484-3257102001e0)


After:
![CleanShot 2025-03-04 at 02 38 32@2x](https://github.com/user-attachments/assets/da58f254-92a3-4210-a44c-c915138d387f)
