### PR TITLE
fix(extras): yazi syntax highlighting

### DIFF
--- a/lua/modus-themes/extras/yazi.lua
+++ b/lua/modus-themes/extras/yazi.lua
@@ -11,7 +11,7 @@ function M.generate(colors)
 
 [manager]
 # NOTE: can combined with tmTheme (sublime colorshceme file) for preview code highlight
-# highlight = "path/to/tmTheme"
+# syntect_theme = "path/to/tmTheme"
 
 cwd = { fg = "${cyan}", italic = true }
 


### PR DESCRIPTION
Yazi uses `syntect_theme` instead of `highlight` for syntax highlighting.

See: https://yazi-rs.github.io/docs/configuration/theme/#mgr.syntect_theme